### PR TITLE
fix: avoid unimported package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const loaderUtils = require('loader-utils');
 const requireFile = require("shaderity-node").requireFile;
 const shaderStage = require("shaderity-node").shaderStage;
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ module.exports = function(source, map, meta) {
 
   const json = {};
 
-  const options = loaderUtils.getOptions(this);
-
   json.code = requireFile(source, this.resourcePath);
 
   json.shaderStage = shaderStage(this.resourcePath);


### PR DESCRIPTION
This PR avoids loading the 'loader-utils'.

The 'loader-utils' has not been imported in package.json and is not used in shaderity-loader.