### PR TITLE
build: remove submodule from master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shaderity-node"]
-	path = shaderity-node
-	url = https://github.com/actnwit/shaderity-node.git


### PR DESCRIPTION
From now on, we will change the way we operate the branch.

We remove the 'shaderity-node' submodule in the master branch to prevent duplicate downloads of it when using the npm published package. We leave the submodules in the newly created 'develop' branch. The only difference between the 'master' branch and the 'develop'  branch is whether 'shaderity-node' is a submodule or not.

